### PR TITLE
Change from type to bytes from string

### DIFF
--- a/flooding/flooding.proto
+++ b/flooding/flooding.proto
@@ -10,7 +10,7 @@ message RPC {
 	}
 	
 	message Message {
-		optional string from = 1;
+		optional bytes from = 1;
 		optional bytes data = 2;
 		optional bytes seqno = 3;
 		repeated string topicCIDs = 4; // CID of topic descriptor object


### PR DESCRIPTION
The string should be always valid UTF-8 data: see string type in the table https://developers.google.com/protocol-buffers/docs/proto#scalar

We are currently sending binary multihash over it. There are some other mistakes like that in IPFS proto files. There might be more in this file.